### PR TITLE
Use species key for ID replacement

### DIFF
--- a/split_dataset.py
+++ b/split_dataset.py
@@ -1,7 +1,12 @@
 """Normalize and split the dataset into individual files.
 
-This script removes sprite data, replaces numeric ID references with names,
-and writes each top-level section of the input file to its own JavaScript file.
+This script removes sprite data and converts numeric ID references to
+human-readable forms. Species IDs are replaced with their key value
+where available so trainers and areas reference Pokémon by key.
+Trainer and item references in areas are also replaced with their
+corresponding names.
+Each top-level section of the input file is then written to its own
+JavaScript file.
 An index.json mapping keys to file paths is generated for convenience.
 """
 
@@ -32,7 +37,14 @@ def build_lookup_tables(data):
     egg_map = {int(eid): name for eid, name in data.get('eggGroups', {}).items()}
     tm_lookup = data.get('tmMoves', {})
     tutor_lookup = data.get('tutorMoves', {})
-    species_map = {int(sid): mon.get('name', sid) for sid, mon in data.get('species', {}).items()}
+    species_map = {
+        int(sid): mon.get('key') or mon.get('name', sid)
+        for sid, mon in data.get('species', {}).items()
+    }
+    trainer_map = {
+        int(tid): t.get('name', tid)
+        for tid, t in data.get('trainers', {}).items()
+    }
     type_map = {int(tid): t.get('name', tid) for tid, t in data.get('types', {}).items()}
     item_map = {int(iid): item.get('name', iid) for iid, item in data.get('items', {}).items()}
     nature_map = {int(nid): name for nid, name in data.get('natures', {}).items()}
@@ -43,6 +55,7 @@ def build_lookup_tables(data):
         tm_lookup,
         tutor_lookup,
         species_map,
+        trainer_map,
         type_map,
         item_map,
         nature_map,
@@ -57,6 +70,7 @@ def replace_ids(data):
         tm_lookup,
         tutor_lookup,
         species_map,
+        trainer_map,
         type_map,
         item_map,
         nature_map,
@@ -106,6 +120,41 @@ def replace_ids(data):
                         poke['nature'] = nature_map.get(poke['nature'], poke['nature'])
                     if 'moves' in poke:
                         poke['moves'] = [move_map.get(mid, mid) for mid in poke['moves']]
+
+    for area in data.get('areas', []):
+        for field in (
+            'wild-day',
+            'wild-night',
+            'wild-surf',
+            'wild-oldRod',
+            'wild-goodRod',
+            'wild-superRod',
+            'wild-smash',
+        ):
+            if field in area:
+                for slot, encounters in area[field].items():
+                    for entry in encounters:
+                        if entry:
+                            entry[0] = species_map.get(entry[0], entry[0])
+
+        for fixed in (
+            'fixed-gift',
+            'fixed-overworld',
+            'fixed-roaming',
+            'fixed-trade',
+        ):
+            if fixed in area:
+                for slot, mons in area[fixed].items():
+                    area[fixed][slot] = [species_map.get(mid, mid) for mid in mons]
+
+        if 'trainers' in area:
+            for slot, ids in area['trainers'].items():
+                area['trainers'][slot] = [trainer_map.get(tid, tid) for tid in ids]
+
+        for key in list(area.keys()):
+            if key.startswith('item-'):
+                for slot, items in area[key].items():
+                    area[key][slot] = [item_map.get(iid, iid) for iid in items]
 
 
 def write_js(path, obj):


### PR DESCRIPTION
## Summary
- convert ID references to use each species `key`
- normalize area encounter references to also use species keys
- convert area trainer and item references to names

## Testing
- `python split_dataset.py -o /tmp/out`


------
https://chatgpt.com/codex/tasks/task_e_68891095bd1c83319d1c1374defbe42b