### PR TITLE
Improve sprites and add lazy Pokedex loading

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,86 @@
+import ast
+import os
+from flask import Flask, render_template, abort, jsonify, request
+
+# Load data
+BASE_DIR = os.path.dirname(__file__)
+DATA_DIR = os.path.join(BASE_DIR, 'split_data')
+
+def load_data(name):
+    path = os.path.join(DATA_DIR, f'{name}.js')
+    with open(path, 'r', encoding='utf-8') as f:
+        return ast.literal_eval(f.read())
+
+species = load_data('species')
+areas = load_data('areas')
+trainers = load_data('trainers')
+items = load_data('items')
+
+# Mapping from species key to its unique species ID for quick lookups
+# This lets us resolve forms such as "Pikachu-Surfing" correctly.
+NAME_TO_ID = {s.get('key', s['name']): s['ID'] for s in species.values()}
+
+# Serve image assets from the graphics directory so templates can reference
+# sprites directly via ``/graphics/...`` URLs.
+app = Flask(
+    __name__,
+    static_url_path='/graphics',
+    static_folder=os.path.join(BASE_DIR, 'graphics')
+)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+# Precompute a sorted list for pagination
+MON_LIST = sorted(species.values(), key=lambda m: m['dexID'])
+
+@app.route('/pokedex')
+def pokedex():
+    return render_template('pokedex.html')
+
+@app.route('/api/pokemon')
+def api_pokemon():
+    try:
+        offset = int(request.args.get('offset', 0))
+        limit = int(request.args.get('limit', 50))
+    except ValueError:
+        abort(400)
+    slice_ = MON_LIST[offset:offset + limit]
+    return jsonify(slice_)
+
+@app.route('/pokemon/<int:species_id>')
+def pokemon(species_id):
+    """Display details for a single species/form by its unique ID."""
+    mon = species.get(species_id)
+    if not mon:
+        abort(404)
+    return render_template('pokemon.html', mon=mon)
+
+@app.route('/areas')
+def area_list():
+    return render_template('areas.html', areas=areas)
+
+@app.route('/areas/<int:idx>')
+def area_detail(idx):
+    if idx < 0 or idx >= len(areas):
+        abort(404)
+    area = areas[idx]
+    def resolve_trainers(ids):
+        return [trainers.get(tid, {'name': tid}) for tid in ids]
+    trainer_groups = {slot: resolve_trainers(ids) for slot, ids in area.get('trainers', {}).items()}
+    return render_template('area.html', area=area, trainers=trainer_groups)
+
+@app.route('/trainer/<int:tid>')
+def trainer_detail(tid):
+    t = trainers.get(tid)
+    if not t:
+        abort(404)
+    party = []
+    for mon in t.get('normal', []):
+        sid = NAME_TO_ID.get(mon.get('species'))
+        party.append({**mon, 'ID': sid})
+    return render_template('trainer.html', trainer=t, party=party)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/area.html
+++ b/templates/area.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+  <head>
+    <title>{{ area.name }}</title>
+  </head>
+  <body>
+    <h1>{{ area.name }}</h1>
+    {% if trainers %}
+    <h2>Trainers</h2>
+    {% for slot, tlist in trainers.items() %}
+      <h3>Group {{ slot }}</h3>
+      <ul>
+      {% for t in tlist %}
+        <li><a href="/trainer/{{ t.get('ID', 0) }}">{{ t.get('name') }}</a></li>
+      {% endfor %}
+      </ul>
+    {% endfor %}
+    {% endif %}
+    {% for field, data in area.items() %}
+      {% if field.startswith('wild-') %}
+      <h2>{{ field.replace('wild-','').replace('Rod',' Rod').title() }}</h2>
+      <ul>
+      {% for slot, entries in data.items() %}
+        {% for entry in entries %}
+          <li>{{ entry[0] }} Lv {{ entry[1] }}-{{ entry[2] }}</li>
+        {% endfor %}
+      {% endfor %}
+      </ul>
+      {% elif field.startswith('item-') %}
+      <h2>Items ({{ field }})</h2>
+      <ul>
+      {% for slot, items in data.items() %}
+        {% for item in items %}
+          <li>{{ item }}</li>
+        {% endfor %}
+      {% endfor %}
+      </ul>
+      {% endif %}
+    {% endfor %}
+    <p><a href="/areas">Back to Areas</a></p>
+  </body>
+</html>

--- a/templates/areas.html
+++ b/templates/areas.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Areas</title>
+  </head>
+  <body>
+    <h1>Areas</h1>
+    <ul>
+    {% for area in areas %}
+      <li><a href="/areas/{{ loop.index0 }}">{{ area.name }}</a></li>
+    {% endfor %}
+    </ul>
+    <p><a href="/">Back</a></p>
+  </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Radical Red Pokedex Viewer</title>
+  </head>
+  <body>
+    <h1>Radical Red Pokedex Viewer</h1>
+    <ul>
+      <li><a href="/pokedex">Pokedex</a></li>
+      <li><a href="/areas">Areas</a></li>
+    </ul>
+  </body>
+</html>

--- a/templates/pokedex.html
+++ b/templates/pokedex.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Pokedex</title>
+  </head>
+  <body>
+    <h1>Pokedex</h1>
+    <ul id="pokedex"></ul>
+    <p><a href="/">Back</a></p>
+    <script>
+      let offset = 0;
+      const limit = 50;
+      async function loadMore() {
+        const res = await fetch(`/api/pokemon?offset=${offset}&limit=${limit}`);
+        const mons = await res.json();
+        const list = document.getElementById('pokedex');
+        for (const mon of mons) {
+          const li = document.createElement('li');
+          li.innerHTML = `<img src="/graphics/species/front/${mon.ID}.png" alt="${mon.name}" style="width:40px;height:40px;vertical-align:middle;"> ` +
+                         `<a href="/pokemon/${mon.ID}">${mon.dexID} - ${mon.name}</a>`;
+          list.appendChild(li);
+        }
+        if (mons.length) {
+          offset += mons.length;
+        }
+      }
+
+      window.addEventListener('scroll', () => {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight - 100) {
+          loadMore();
+        }
+      });
+      loadMore();
+    </script>
+  </body>
+</html>

--- a/templates/pokemon.html
+++ b/templates/pokemon.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <title>{{ mon.name }}</title>
+  </head>
+  <body>
+    <h1>{{ mon.name }}</h1>
+    {# Display the sprite using the dex ID with transparency #}
+    <img src="/graphics/species/front/{{ mon.ID }}.png" alt="{{ mon.name }}">
+    <p>Dex ID: {{ mon.dexID }}</p>
+    <p>Type: {{ mon.type|join(', ') }}</p>
+    <p>Stats: {{ mon.stats }}</p>
+    <p><a href="/pokedex">Back to Pokedex</a></p>
+  </body>
+</html>

--- a/templates/trainer.html
+++ b/templates/trainer.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <head>
+    <title>{{ trainer.name }}</title>
+  </head>
+  <body>
+    <h1>{{ trainer.name }}</h1>
+    <img src="/graphics/trainers/{{ trainer.ID }}.png" alt="{{ trainer.name }}">
+    <h2>Pokemon</h2>
+    {% for poke in party %}
+      <div style="margin-bottom:10px;">
+        <img src="/graphics/species/front/{{ poke.ID }}.png" alt="{{ poke.species }}" style="width:40px;height:40px;vertical-align:middle;">
+        <strong>{{ poke.species }}</strong> Lv {{ poke.level }}<br>
+        Moves: {{ poke.moves|join(', ') }}
+      </div>
+    {% endfor %}
+    <p><a href="/areas">Back to Areas</a></p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- switch species sprites to use transparent images in `/graphics/species/front/<id>.png`
- paginate Pokedex data via `/api/pokemon` and load entries as the user scrolls
- fix sprite lookup for Pokémon forms

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688929c429048331b2690864a6f730bb